### PR TITLE
[Feat/SSR-5] fix: 클래스 이름으로 사용하던 프로토이름 수정

### DIFF
--- a/client/client.proto
+++ b/client/client.proto
@@ -50,7 +50,7 @@ message MoveInfo {
   Rotation rotation = 2;
 }
 
-message Player {
+message PlayerInfo {
   string userId = 1;
   MoveInfo moveInfo = 2;
   bool isHost = 3;
@@ -67,7 +67,7 @@ message PlayerStateInfo {
   CharacterState characterState = 2;
 }
 
-message Ghost {
+message GhostInfo {
   uint32 ghostId = 1;
   uint32 ghostTypeId = 2;
   MoveInfo moveInfo = 3;
@@ -169,7 +169,7 @@ message C2S_JoinRoomRequest {
 message S2C_JoinRoomResponse {
   GlobalFailCode globalFailCode  = 1;
   string message = 2;
-  repeated Player players = 3;
+  repeated PlayerInfo playerInfos = 3;
 }
 
 message S2C_JoinRoomNotification {
@@ -187,14 +187,14 @@ message S2C_SpawnInitialDataRequest	{
 }
 
 message C2S_SpawnInitialDataResponse {
-  repeated Ghost ghosts = 1;
+  repeated GhostInfo ghostInfos = 1;
   repeated ItemInfo itemInfos = 2;
 }
 
 message S2C_StartStageNotification {
   GlobalFailCode globalFailCode  = 1;
   string message = 2;
-  repeated Ghost ghosts = 3;
+  repeated GhostInfo ghostInfos = 3;
   repeated ItemInfo itemInfos = 4;
 }
 

--- a/game/src/protobufs/game/game.data.proto
+++ b/game/src/protobufs/game/game.data.proto
@@ -21,7 +21,7 @@ message MoveInfo {
   Rotation rotation = 2;
 }
 
-message Player {
+message PlayerInfo {
   string userId = 1;
   MoveInfo moveInfo = 2;
   bool isHost = 3;
@@ -38,7 +38,7 @@ message PlayerStateInfo {
   CharacterState characterState = 2;
 }
 
-message Ghost {
+message GhostInfo {
   uint32 ghostId = 1;
   uint32 ghostTypeId = 2;
   MoveInfo moveInfo = 3;

--- a/game/src/protobufs/game/game.packet.proto
+++ b/game/src/protobufs/game/game.packet.proto
@@ -103,14 +103,14 @@ message S2C_SpawnInitialDataRequest	{
 }
 
 message C2S_SpawnInitialDataResponse {
-  repeated Ghost ghosts = 1;
+  repeated GhostInfo ghostInfos = 1;
   repeated ItemInfo itemInfos = 2;
 }
 
 message S2C_StartStageNotification {
   GlobalFailCode globalFailCode  = 1;
   string message = 2;
-  repeated Ghost ghosts = 3;
+  repeated GhostInfo ghostInfos = 3;
   repeated ItemInfo itemInfos = 4;
 }
 

--- a/game/src/response/auth.response.js
+++ b/game/src/response/auth.response.js
@@ -48,7 +48,7 @@ export const sendConnectGameResponse = (socket, gameSession, existUserIds) => {
     gameId: gameSession.id,
     hostId: gameSession.hostId,
     existUserIds: existUserIds,
-    ghosts: ghosts,
+    ghostInfos: ghosts,
     ghostTypeIds: [1, 1], // 임시 고스트 타입 5마리 소환하라고 보냅니다.
     globalFailCode: GLOBAL_FAIL_CODE.NONE,
     userState: USER_STATE.INGAME,

--- a/game/src/response/room/room.response.js
+++ b/game/src/response/room/room.response.js
@@ -35,7 +35,7 @@ export const sendJoinRoomResponse = (socket, game) => {
   const data = {
     globalFailCode: GLOBAL_FAIL_CODE.NONE,
     message: '방에 성공적으로 참가하였습니다.',
-    players,
+    playerInfos: players,
   };
   const responseData = serializer(PACKET_TYPE.JoinRoomResponse, data, 0); // sequence도 임시로
   socket.write(responseData);


### PR DESCRIPTION
- 클라이언트에서 클래스로 사용하는 이름을 프로토 메시지이름으로 사용 시, 상속이 불가한 이슈 발생하여 수정