### PR TITLE
[Feat/SSR-5] fix: 프로토 수정 작업

### DIFF
--- a/client/client.proto
+++ b/client/client.proto
@@ -191,15 +191,13 @@ message S2C_SpawnInitialDataRequest	{
 }
 
 message C2S_SpawnInitialDataResponse {
-  repeated GhostInfo ghostInfos = 1;
-  repeated ItemInfo itemInfos = 2;
+  repeated ItemInfo itemInfos = 1;
 }
 
 message S2C_StartStageNotification {
   GlobalFailCode globalFailCode  = 1;
   string message = 2;
-  repeated GhostInfo ghostInfos = 3;
-  repeated ItemInfo itemInfos = 4;
+  repeated ItemInfo itemInfos = 3;
 }
 
 message C2S_PlayerAttackedRequest {
@@ -306,6 +304,25 @@ message S2C_ItemDisuseNotification {
   uint32 itemId  = 2;
 }
 
+message C2S_ItemCreateRequest {
+  ItemInfo itemInfo = 1;
+}
+
+message S2C_ItemCreateNotification {
+  ItemInfo itemInfo = 1;
+}
+
+message S2C_BlockInteractionNotification {
+}
+
+message C2S_GhostSpawnRequest {
+  GhostInfo ghostInfo = 1;
+}
+
+message C2S_GhostSpawnNotification {
+  GhostInfo ghostInfo = 1;
+}
+
 message GamePacket {
   oneof payload {
     C2S_PlayerMoveRequest playerMoveRequest = 1;
@@ -350,5 +367,10 @@ message GamePacket {
     S2C_DisconnectPlayerNotification disconnectPlayerNotification = 43;
     C2S_GhostSpecialStateRequest ghostSpecialStateRequest = 44;
     S2C_GhostSpecialStateNotification ghostSpecialStateNotification = 45;
+    C2S_ItemCreateRequest itemCreateRequest = 46;
+    S2C_ItemCreateNotification itemCreateNotification = 47;
+    S2C_BlockInteractionNotification blockInteractionNotification = 48;
+    C2S_GhostSpawnRequest ghostSpawnRequest = 49;
+    C2S_GhostSpawnNotification ghostSpawnNotification = 50;
   }
 }

--- a/game/src/protobufs/common/common.packet.proto
+++ b/game/src/protobufs/common/common.packet.proto
@@ -46,8 +46,10 @@ message GamePacket {
     S2C_DisconnectPlayerNotification disconnectPlayerNotification = 43;
     C2S_GhostSpecialStateRequest ghostSpecialStateRequest = 44;
     S2C_GhostSpecialStateNotification ghostSpecialStateNotification = 45;
-    S2C_ItemDeleteNotification itemDeleteNotification = 46;
-    C2S_ItemDisuseRequest itemDisuseRequest = 47;
-    S2C_ItemDisuseNotification itemDisuseNotification = 48;
+    C2S_ItemCreateRequest itemCreateRequest = 46;
+    S2C_ItemCreateNotification itemCreateNotification = 47;
+    S2C_BlockInteractionNotification blockInteractionNotification = 48;
+    C2S_GhostSpawnRequest ghostSpawnRequest = 49;
+    C2S_GhostSpawnNotification ghostSpawnNotification = 50;
   }
 }

--- a/game/src/protobufs/game/game.packet.proto
+++ b/game/src/protobufs/game/game.packet.proto
@@ -106,15 +106,13 @@ message S2C_SpawnInitialDataRequest	{
 }
 
 message C2S_SpawnInitialDataResponse {
-  repeated GhostInfo ghostInfos = 1;
-  repeated ItemInfo itemInfos = 2;
+  repeated ItemInfo itemInfos = 1;
 }
 
 message S2C_StartStageNotification {
   GlobalFailCode globalFailCode  = 1;
   string message = 2;
-  repeated GhostInfo ghostInfos = 3;
-  repeated ItemInfo itemInfos = 4;
+  repeated ItemInfo itemInfos = 3;
 }
 
 message C2S_PlayerAttackedRequest {
@@ -219,4 +217,23 @@ message C2S_ItemDisuseRequest {
 message S2C_ItemDisuseNotification {
   uint32 userId = 1;
   uint32 itemId  = 2;
+}
+
+message C2S_ItemCreateRequest {
+  ItemInfo itemInfo = 1;
+}
+
+message S2C_ItemCreateNotification {
+  ItemInfo itemInfo = 1;
+}
+
+message S2C_BlockInteractionNotification {
+}
+
+message C2S_GhostSpawnRequest {
+  GhostInfo ghostInfo = 1;
+}
+
+message C2S_GhostSpawnNotification {
+  GhostInfo ghostInfo = 1;
 }


### PR DESCRIPTION
1. SpawnInitialRequest 에서 Ghosts는 따로 빼기 => 클라에서 initial 혹은 중간에 생성되는 귀신 모두 생성될 때 spawnRequest를 보내는 방향 => 귀신은 spawnReqeust에 따른 Noti 날려주도록 하기

2. 아이템도 중간에 생성될 수 있으니 createItemRequest에 따른 Noti 날려주기 => 랜턴이나 상점 구매 아이템은 바닥에 떨어질거니 createItemReq / 소울 아이템은 동일하게 itemInfos로 받아서 처리

3. startStageRequest 들어오면 blockInteractionNotification 날려주기 => 클라이언트 상호작용 막기 위함