### PR TITLE
[Feat/SSR-5] fix: 아이템 생성 요청 패킷에 타입 아이디만 주는 것으로 수정

### DIFF
--- a/client/client.proto
+++ b/client/client.proto
@@ -305,7 +305,7 @@ message S2C_ItemDisuseNotification {
 }
 
 message C2S_ItemCreateRequest {
-  ItemInfo itemInfo = 1;
+  uint32 itemTypeId = 1;
 }
 
 message S2C_ItemCreateNotification {

--- a/game/src/protobufs/game/game.packet.proto
+++ b/game/src/protobufs/game/game.packet.proto
@@ -220,7 +220,7 @@ message S2C_ItemDisuseNotification {
 }
 
 message C2S_ItemCreateRequest {
-  ItemInfo itemInfo = 1;
+  uint32 itemTypeId = 1;
 }
 
 message S2C_ItemCreateNotification {


### PR DESCRIPTION
-> 소울 아이템 생성은 호스트가 담당
-> 소울 아이템 외에는 서버가 생성을 담당하고 통지하는 방향