### PR TITLE
[Feat/SSR-58] fix: 귀신 소환 요청 핸들러에서 소환 지점과 아이디를 서버에서 생성하고 응답하도록 수정

### DIFF
--- a/client/client.proto
+++ b/client/client.proto
@@ -318,7 +318,7 @@ message S2C_BlockInteractionNotification {
 }
 
 message C2S_GhostSpawnRequest {
-  GhostInfo ghostInfo = 1;
+  uint32 ghostTypeId = 1;
 }
 
 message S2C_GhostSpawnNotification {

--- a/game/src/classes/models/game.class.js
+++ b/game/src/classes/models/game.class.js
@@ -23,12 +23,14 @@ class Game {
     this.items = [];
     this.doors = [];
     this.state = GAME_SESSION_STATE.PREPARE;
+    this.ghostSpawnPositions = null;
     this.difficultyId = null;
     this.remainingTime = null;
     this.ghostCSpawn = false;
 
     this.goalSoulAmount = 0;
     this.soulAccumulatedAmount = 0;
+    this.ghostIdCount = 1;
 
     this.inviteCode = getInviteCode();
     this.itemQueue = new ItemQueueManager(id);
@@ -48,6 +50,9 @@ class Game {
     this.remainingTime = gameAssets.difficulty.data.find(
       (data) => data.id === this.difficultyId,
     );
+
+    // 귀신 스폰 가능 지점 초기화
+    this.ghostSpawnPositions = [...gameAssets.ghostSpawnPos.data];
 
     // IntervalManager.getInstance().addPlayersInterval(
     //   this.id,

--- a/game/src/handlers/game/ghost/ghostSpawn.handler.js
+++ b/game/src/handlers/game/ghost/ghostSpawn.handler.js
@@ -4,15 +4,14 @@ import { getGameSessionById } from '../../../sessions/game.session.js';
 import { getUserById } from '../../../sessions/user.sessions.js';
 import Ghost from '../../../classes/models/ghost.class.js';
 import { ghostSpawnNotification } from '../../../notifications/ghost/ghost.notification.js';
+import { getRandomInt } from '../../../utils/math/getRandomInt.js';
 
 /**
  * 귀신의 특수 상태 요청에 대한 핸들러 함수입니다. (호스트만 요청)
  */
 export const ghostSpawnHandler = ({ socket, payload }) => {
   try {
-    const { ghostInfo } = payload;
-
-    const { position, rotation } = ghostInfo.moveInfo;
+    const { ghostTypeId } = payload;
 
     const user = getUserById(socket.userId);
     if (!user) {
@@ -24,14 +23,44 @@ export const ghostSpawnHandler = ({ socket, payload }) => {
       throw new CustomError(ErrorCodesMaps.GAME_NOT_FOUND);
     }
 
+    const positionIndex = getRandomInt(
+      0,
+      gameSession.ghostSpawnPositions.length,
+    );
+    const ghostPosition = gameSession.ghostSpawnPositions.splice(
+      positionIndex,
+      1,
+    );
+    const positions = ghostPosition[0].GhostSpawnPos.split(',').map(
+      (position) => {
+        return Number(position);
+      },
+    );
+    const rotation = { x: 0, y: 0, z: 0 };
+    const position = {
+      x: positions[0],
+      y: positions[1],
+      z: positions[2],
+    };
+
     const ghost = new Ghost(
-      ghostInfo.id,
-      ghostInfo.ghostTypeId,
+      gameSession.ghostIdCount++,
+      ghostTypeId,
       position,
       rotation,
     );
-
     gameSession.addGhost(ghost);
+
+    const moveInfo = {
+      position,
+      rotation,
+    };
+
+    const ghostInfo = {
+      ghostId: ghost.id,
+      ghostTypeId,
+      moveInfo,
+    };
 
     ghostSpawnNotification(gameSession, ghostInfo);
   } catch (e) {

--- a/game/src/notifications/ghost/ghost.notification.js
+++ b/game/src/notifications/ghost/ghost.notification.js
@@ -151,14 +151,11 @@ export const ghostSpecialStateNotification = (gameSession, payload) => {
 // 귀신 생성 알림
 export const ghostSpawnNotification = (gameSession, ghostInfo) => {
   gameSession.users.forEach((user) => {
-    if (gameSession.hostId !== user.id) {
-      const packet = serializer(
-        PACKET_TYPE.GhostSpawnNotification,
-        ghostInfo,
-        user.socket.sequence++,
-      );
-
-      user.socket.write(packet);
-    }
+    const packet = serializer(
+      PACKET_TYPE.GhostSpawnNotification,
+      ghostInfo,
+      user.socket.sequence++,
+    );
+    user.socket.write(packet);
   });
 };

--- a/game/src/protobufs/game/game.packet.proto
+++ b/game/src/protobufs/game/game.packet.proto
@@ -232,7 +232,7 @@ message S2C_BlockInteractionNotification {
 }
 
 message C2S_GhostSpawnRequest {
-  GhostInfo ghostInfo = 1;
+  uint32 ghostTypeId = 1;
 }
 
 message S2C_GhostSpawnNotification {

--- a/game/src/utils/math/getRandomInt.js
+++ b/game/src/utils/math/getRandomInt.js
@@ -1,0 +1,5 @@
+export const getRandomInt = (min, max) => {
+  const minCeiled = Math.ceil(min);
+  const maxFloored = Math.floor(max);
+  return Math.floor(Math.random() * (maxFloored - minCeiled) + minCeiled);
+};


### PR DESCRIPTION
1. GhostSpawnRequest에 ghostTypeId만 받는 것으로 수정되면서 서버에서 소환 위치와 아이디를 부여하고 Notification 날려주는 방향으로 변경

2. 호스트에게도 귀신 소환 Noti 날려주도록 변경